### PR TITLE
Improve assertion usages in test suite

### DIFF
--- a/test/Document/QueryTest.php
+++ b/test/Document/QueryTest.php
@@ -77,7 +77,7 @@ class QueryTest extends TestCase
             "//div[@id='foo']//span[contains(concat(' ', normalize-space(@class), ' '), ' bar ')]",
             "//*[@id='bar']//li[contains(concat(' ', normalize-space(@class), ' '), ' baz ')]//a",
         ];
-        $this->assertEquals(count($expected), count($actual));
+        $this->assertCount(count($expected), $actual);
         foreach ($actual as $path) {
             $this->assertContains($path, $expected);
         }

--- a/test/DocumentTest.php
+++ b/test/DocumentTest.php
@@ -58,6 +58,7 @@ class DocumentTest extends TestCase
     public function testConstructorShouldNotRequireArguments()
     {
         $document = new Document();
+        $this->assertInstanceOf(Document::class, $document);
     }
 
     public function testConstructorShouldAcceptDocumentString()
@@ -178,7 +179,7 @@ class DocumentTest extends TestCase
     {
         $this->loadHtml();
         $result = Document\Query::execute('div[data-attr="foo bar baz"]', $this->document, Document\Query::TYPE_CSS);
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
     }
 
     public function testQueryShouldFindNodesWithArbitraryAttributeSelectorsAsDiscreteWords()
@@ -206,11 +207,15 @@ class DocumentTest extends TestCase
     {
         $this->loadHtml();
         try {
-            $result = Document\Query::execute(
+            Document\Query::execute(
                 '//meta[php:functionString("strtolower", @http-equiv) = "content-type"]',
                 $this->document
             );
         } catch (\Exception $e) {
+            $this->assertSame(
+                'DOMXPath::query(): xmlXPathCompOpEval: function functionString bound to undefined prefix php',
+                $e->getMessage()
+            );
             return;
         }
         $this->fail('XPath PHPFunctions should be disabled by default');
@@ -235,12 +240,12 @@ class DocumentTest extends TestCase
         $this->loadHtml();
         try {
             $this->document->registerXpathPhpFunctions('stripos');
-            $result = Document\Query::execute(
+            Document\Query::execute(
                 '//meta[php:functionString("strtolower", @http-equiv) = "content-type"]',
                 $this->document
             );
         } catch (\Exception $e) {
-            // $e->getMessage() - Not allowed to call handler 'strtolower()
+            $this->assertSame('DOMXPath::query(): Not allowed to call handler \'strtolower()\'.', $e->getMessage());
             return;
         }
         $this->fail('Not allowed to call handler strtolower()');

--- a/test/DocumentTest.php
+++ b/test/DocumentTest.php
@@ -17,7 +17,6 @@ use Laminas\Dom\Exception\ExceptionInterface as DOMException;
 use Laminas\Dom\Exception\RuntimeException;
 use PHPUnit\Framework\TestCase;
 
-use function count;
 use function file_get_contents;
 use function restore_error_handler;
 use function set_error_handler;


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no
| Tests        | yes

### Description

- Using the `assertCount` to assert expected count is same as result count.
- Using the `assertSame` to assert exception message when catching block has been triggered on some testing methods.
- Removing some variables because they're declared, but not used.