### PR TITLE
Drop `laminas/laminas-zendframework-bridge` and `zendframework/*` compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
     "require": {
         "php": "^7.3 || ~8.0.0",
         "ext-dom": "*",
-        "ext-libxml": "*",
-        "laminas/laminas-zendframework-bridge": "^1.1"
+        "ext-libxml": "*"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "^2.1.4",
@@ -54,7 +53,7 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },
-    "replace": {
-        "zendframework/zend-dom": "^2.7.2"
+    "conflict": {
+        "zendframework/zend-dom": "*"
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description


Increase performance by removing a compatibility layer while **not** introducing breaking changes.

This follow the process described in details in:

https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2021-08-02-TSC-Minutes.md#remove-laminaslaminas-zendframework-bridge-dependency-from-our-packages
